### PR TITLE
feat(frontend): chat/master API クライアントの TODO スタブを実装する (#21)

### DIFF
--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,5 +1,4 @@
-// Chat API: send messages and manage RAG responses
-// TODO: Implement chat endpoints
+// Chat API: メッセージ送信・履歴取得・評価
 
 import { apiClient } from "./client";
 import type { Message } from "../types/message";
@@ -16,32 +15,22 @@ export interface SendMessageResponse {
   sessionId: string;
 }
 
-/**
- * TODO: Send a user message and get the assistant response.
- * For streaming, use the SSE client instead.
- */
+/** ユーザーメッセージを送信し、生成された assistant メッセージの ID を返す（ストリーミング応答が必要な場合は SSE クライアントを利用する） */
 export async function sendMessage(
-  _request: SendMessageRequest
+  request: SendMessageRequest
 ): Promise<SendMessageResponse> {
-  // TODO: implement
-  return apiClient.post<SendMessageResponse>("/chat/messages", _request as unknown as Record<string, string>);
+  return apiClient.post<SendMessageResponse>("/chat/messages", { ...request });
 }
 
-/**
- * TODO: Get all messages for a session.
- */
-export async function getMessages(_sessionId: string): Promise<Message[]> {
-  // TODO: implement
-  return apiClient.get<Message[]>(`/chat/sessions/${_sessionId}/messages`);
+/** 指定セッションに紐づくメッセージ履歴を時系列で取得する */
+export async function getMessages(sessionId: string): Promise<Message[]> {
+  return apiClient.get<Message[]>(`/chat/sessions/${sessionId}/messages`);
 }
 
-/**
- * TODO: Rate a message (thumbs up/down).
- */
+/** メッセージに評価値（thumbs up/down）を付与する */
 export async function rateMessage(
-  _messageId: string,
-  _rating: number
+  messageId: string,
+  rating: number
 ): Promise<void> {
-  // TODO: implement
-  return apiClient.put<void>(`/messages/${_messageId}/rating`, { rating: _rating });
+  return apiClient.put<void>(`/messages/${messageId}/rating`, { rating });
 }

--- a/frontend/src/api/master.ts
+++ b/frontend/src/api/master.ts
@@ -1,29 +1,40 @@
-// Master data API: sites, lines, processes
-// TODO: Implement master data endpoints
+// Master データ API: サイト・ライン・工程の参照
 
 import { apiClient } from "./client";
 import type { SiteMaster, LineMaster, ProcessMaster } from "../types/master";
 
-/**
- * TODO: Get all site master records.
- */
+interface SitesResponse {
+  sites: SiteMaster[];
+}
+
+interface LinesResponse {
+  lines: LineMaster[];
+}
+
+interface ProcessesResponse {
+  processes: ProcessMaster[];
+}
+
+/** サイトマスタの一覧をマスターキャッシュから取得する */
 export async function getSites(): Promise<SiteMaster[]> {
-  // TODO: implement
-  return apiClient.get<SiteMaster[]>("/master/sites");
+  const response = await apiClient.get<SitesResponse>("/master/sites");
+  return response.sites;
 }
 
-/**
- * TODO: Get lines for a given site.
- */
-export async function getLines(_siteCode: string): Promise<LineMaster[]> {
-  // TODO: implement
-  return apiClient.get<LineMaster[]>(`/master/lines?siteCode=${_siteCode}`);
+/** 指定サイトに属するライン一覧を取得する */
+export async function getLines(siteCode: string): Promise<LineMaster[]> {
+  const query = new URLSearchParams({ site_code: siteCode });
+  const response = await apiClient.get<LinesResponse>(
+    `/master/lines?${query.toString()}`
+  );
+  return response.lines;
 }
 
-/**
- * TODO: Get processes for a given line.
- */
-export async function getProcesses(_lineCode: string): Promise<ProcessMaster[]> {
-  // TODO: implement
-  return apiClient.get<ProcessMaster[]>(`/master/processes?lineCode=${_lineCode}`);
+/** 指定ラインに属する工程一覧を取得する */
+export async function getProcesses(lineCode: string): Promise<ProcessMaster[]> {
+  const query = new URLSearchParams({ line_code: lineCode });
+  const response = await apiClient.get<ProcessesResponse>(
+    `/master/processes?${query.toString()}`
+  );
+  return response.processes;
 }

--- a/frontend/src/types/master.ts
+++ b/frontend/src/types/master.ts
@@ -7,11 +7,12 @@ export interface SiteMaster {
 export interface LineMaster {
   code: string;
   name: string;
-  siteCode: string;
+  site_code: string;
+  aliases: string[];
 }
 
 export interface ProcessMaster {
   code: string;
   name: string;
-  lineCode: string;
+  line_code: string;
 }


### PR DESCRIPTION
## Summary
- `frontend/src/api/chat.ts` と `frontend/src/api/master.ts` の TODO スタブを `sessions.ts` / `documents.ts` と同じ書き味に揃え、API クライアントを正式実装に格上げ。
- chat.ts: `_underscore` プレフィックス除去 / `Record<string, string>` 二重キャスト撤廃（`{ ...request }` で構造的に Record-互換へ）/ JSDoc を本番用に書き換え。
- master.ts: クエリを `URLSearchParams` で組み立て、バックエンド (`backend/app/routers/master.py`) のクエリ名 `site_code` / `line_code` と response wrapper (`{sites,lines,processes}: [...]`) に合わせて整合化。
- types/master.ts: `LineMaster.siteCode → site_code` / `ProcessMaster.lineCode → line_code` / `LineMaster.aliases` 追加で backend レスポンスと型整合。

## Type / Lint / Test
- `npm run typecheck` ✅ クリーン
- `npm run lint` ✅ 変更ファイル (chat.ts / master.ts / types/master.ts) は **0 warnings / 0 errors**（既存 11 warnings はリポジトリ内の他ファイルで本 PR とは無関係）
- 受け入れ条件にあった `frontend/e2e/chat.spec.ts` は本リポジトリには存在せず（issue 本文の参照コミット `cc19847` も現 main には未マージ）。`StarRating.tsx` から呼ばれている `rateMessage` のシグネチャは互換維持しているため、既存 e2e (`accessibility / knowledge-bases / navigation / settings / upload`) への影響なし。

## Behavior changes worth noting
- `getSites/getLines/getProcesses` の戻り値は backend と一致する形へ調整（snake_case のキーで揃え、配列を unwrap）。
- 現状フロントエンドの UI 層から `getSites/getLines/getProcesses/getMessages/sendMessage` は呼び出されていないため互換は確保済み。`StarRating` から呼ばれる `rateMessage(messageId, rating)` のシグネチャは維持。

## Test plan
- [ ] `cd frontend && npm run typecheck`
- [ ] `cd frontend && npm run lint`
- [ ] `cd frontend && npx playwright test` （既存 e2e の回帰がないこと）
- [ ] master/sites|lines|processes を呼ぶ画面が今後追加された際、snake_case フィールドにアクセスする実装になっているかを再確認

Closes #21
