### PR TITLE
test(backend): pytest カバレッジ計測の導入と最低ラインの設定 (#25)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = [
+    "--strict-markers",
+    "-ra",
+]
+markers = [
+    "slow: 実時間がかかるテスト（CI で skip 可）",
+    "integration: 外部サービス（Qdrant / Bedrock / Oracle）に依存するテスト",
+]
+
+[tool.coverage.run]
+source = ["app"]
+branch = true
+omit = [
+    "app/main.py",
+    "*/__pycache__/*",
+    "*/tests/*",
+    "*/migrations/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+precision = 1
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]
+# 当面の最低ライン。現状把握後に段階的に引き上げる。
+fail_under = 40

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,4 +22,5 @@ python-jose>=3.3.0
 # Testing
 pytest>=8.3.0
 pytest-asyncio>=0.24.0
+pytest-cov>=5.0.0
 moto>=5.0.0


### PR DESCRIPTION
## Summary
- `backend/requirements.txt` に `pytest-cov>=5.0.0` を追加
- `backend/pyproject.toml` を新規作成し pytest 設定 + coverage 設定を集約
- `coverage.report.fail_under = 40` で最低ラインをガード（issue 本文の方針どおり）
- README へのカバレッジセクション追記は #28 (README/CLAUDE.md/AGENTS.md 整備) でまとめて対応する想定で deferred

## 変更内容
| ファイル | 変更 |
|---|---|
| `backend/requirements.txt` | `pytest-cov>=5.0.0` を Testing セクションに追加 |
| `backend/pyproject.toml` | 新規作成。pytest（testpaths / asyncio_mode / strict-markers / カスタムマーカー）と coverage（source=["app"] / branch=true / omit / fail_under=40） を集約 |

### pyproject.toml の主要設定
```toml
[tool.pytest.ini_options]
testpaths = ["tests"]
asyncio_mode = "auto"
markers = [
    "slow: 実時間がかかるテスト（CI で skip 可）",
    "integration: 外部サービス依存",
]

[tool.coverage.run]
source = ["app"]
branch = true
omit = ["app/main.py", "*/__pycache__/*", "*/tests/*", "*/migrations/*"]

[tool.coverage.report]
fail_under = 40
```

### ファイル毎カバレッジ要求（issue 本文より）
- `services/rag.py` 配下と `services/duckdb_query.py` 配下の **新規追加コード** は 70% 以上
- 上記はリポジトリ全体の `fail_under` ではなくレビュー時の運用ルール（PR レビュー観点）として扱う

## Test plan
- [ ] `cd backend && pip install -r requirements.txt` で `pytest-cov` がインストールされる
- [ ] `cd backend && pytest --cov=app --cov-report=term` でカバレッジサマリが出る
- [ ] `cd backend && pytest --cov=app --cov-report=xml` で `coverage.xml` が生成される（CI #24 で利用予定）
- [ ] 既存の 8 テストファイルが `pyproject.toml` の testpaths から問題なく拾われる

## 次の作業（依存 issue）
- #24（CI 統合）: `pytest --cov=app --cov-report=xml --cov-report=term` を backend ジョブに組み込む
- #28（README/CLAUDE.md 整備）: README にカバレッジバッジ + ローカル実行コマンドを追記

Closes #25
